### PR TITLE
Use csv package instead of unicodecsv

### DIFF
--- a/ncats_webd/blueprints/stakeholders/contacts.py
+++ b/ncats_webd/blueprints/stakeholders/contacts.py
@@ -14,7 +14,7 @@ Options:
 
 # standard python libraries
 import StringIO
-from unicodecsv import DictWriter
+from csv import DictWriter
 
 # third-party libraries (install with pip)
 from docopt import docopt


### PR DESCRIPTION
Since `unicodecsv` isn't a standard library in Python 2.x