### PR TITLE
Ensure Legacy Ticket Queries Specify Nessus as Source

### DIFF
--- a/extras/data-pusher/data-pusher.py
+++ b/extras/data-pusher/data-pusher.py
@@ -73,7 +73,7 @@ def get_ticket_severity_counts(db, stakeholders):
         else:
             current_org_list = [org['_id']]
         tix = db.tickets.aggregate([
-            {'$match':{'open':True, 'owner':{'$in':current_org_list}, 'false_positive':False}},
+            {'$match':{'open':True, 'source': 'nessus', 'owner':{'$in':current_org_list}, 'false_positive':False}},
             {'$group': {'_id': {},
                         'critical_tix_open':{'$sum':{'$cond':[{'$eq':['$details.severity',4]}, 1, 0]}},
                         'high_tix_open':{'$sum':{'$cond':[{'$eq':['$details.severity',3]}, 1, 0]}}
@@ -98,10 +98,10 @@ def get_overall_metrics(db, stakeholders):
     results['stakeholders'] = len(stakeholders)
     results['addresses'] = db.hosts.count()
     results['hosts'] = db.hosts.find({'state.up':True}).count()
-    results['vulnerable_hosts'] = len(db.tickets.find({'open':True, 'false_positive':False}).distinct('ip_int'))
+    results['vulnerable_hosts'] = len(db.tickets.find({'open':True, 'source': 'nessus', 'false_positive':False}).distinct('ip_int'))
 
     tix = db.tickets.aggregate([
-        {'$match':{'open':True, 'false_positive':False}},
+        {'$match':{'open':True, 'source': 'nessus', 'false_positive':False}},
         {'$group': {'_id': {},
              'low_tix_open':{'$sum':{'$cond':[{'$eq':['$details.severity',1]}, 1, 0]}},
              'medium_tix_open':{'$sum':{'$cond':[{'$eq':['$details.severity',2]}, 1, 0]}},
@@ -155,10 +155,10 @@ def get_tally_details(db):
 
 def get_open_ticket_loc_by_severity(db, severity=None):
     if severity != None:
-        tickets = db.TicketDoc.collection.find({'open':True, 'details.severity':severity, 'loc.0':{'$ne':None}},
+        tickets = db.TicketDoc.collection.find({'open':True, 'source': 'nessus', 'details.severity':severity, 'loc.0':{'$ne':None}},
                                                {'_id':0,'loc':1,'details.severity':1})
     else:
-        tickets = db.TicketDoc.collection.find({'open':True, 'loc.0':{'$ne':None}},{'_id':0,'loc':1,'details.severity':1})
+        tickets = db.TicketDoc.collection.find({'open':True, 'source': 'nessus', 'loc.0':{'$ne':None}},{'_id':0,'loc':1,'details.severity':1})
     return list(tickets)
 
 def get_running_ips(db):

--- a/ncats_webd/blueprints/bod/bod.py
+++ b/ncats_webd/blueprints/bod/bod.py
@@ -50,7 +50,7 @@ def schedule_broadcaster():
 
 def get_bod_open_tickets_dataframe(bod_start_date):
     bod_owners = current_app.db.RequestDoc.get_all_descendants('EXECUTIVE')
-    tix = current_app.db.TicketDoc.find({'details.severity':4, 'false_positive':False, 'owner':{'$in':bod_owners}, 'open':True},
+    tix = current_app.db.TicketDoc.find({'source': 'nessus', 'details.severity':4, 'false_positive':False, 'owner':{'$in':bod_owners}, 'open':True},
         {'_id':False, 'owner':True, 'time_opened':True, 'ip':True, 'port':True, 'details.name':True, 'details.cve':True})
     tix = list(tix)
     for x in tix:
@@ -76,7 +76,7 @@ def get_bod_dataframe(bod_start_date):
 
     bod_owners = current_app.db.RequestDoc.get_all_descendants('EXECUTIVE')
 
-    backlog_tix = current_app.db.TicketDoc.find({'details.severity':4, 'owner':{'$in':bod_owners},
+    backlog_tix = current_app.db.TicketDoc.find({'source': 'nessus', 'details.severity':4, 'owner':{'$in':bod_owners},
                      'time_opened':{'$lte':bod_start_date}, 'false_positive':False,
                      '$or':[{'time_closed':{'$gte':bod_start_date}}, {'time_closed':None}] },
                      {'_id':False, 'time_closed':True})
@@ -99,7 +99,7 @@ def get_bod_dataframe(bod_start_date):
     else:
         df_backlog = DataFrame()
     # Calculate Buckets
-    tix = current_app.db.TicketDoc.find({'details.severity':4, 'false_positive':False, 'owner':{'$in':bod_owners},
+    tix = current_app.db.TicketDoc.find({'source': 'nessus', 'details.severity':4, 'false_positive':False, 'owner':{'$in':bod_owners},
                             '$or':[{'time_closed':{'$gte':bod_start_date}}, {'time_closed':None}]},
                             {'_id':False, 'time_opened':True, 'time_closed':True})
     df = DataFrame(list(tix))

--- a/ncats_webd/blueprints/dashboard/dashboard.py
+++ b/ncats_webd/blueprints/dashboard/dashboard.py
@@ -51,7 +51,7 @@ class TicketFeed(object):
 
     def __check_database(self):
         now = util.utcnow()
-        tickets = self.__db.tickets.find({'last_change':{'$gt':self.__since}},
+        tickets = self.__db.tickets.find({'source':'nessus', 'last_change':{'$gt':self.__since}},
                                          {'_id':1,'owner':1, 'details':1, 'events.action':1, 'events':{'$slice':-1}}) \
                                          .sort([('last_change',-1)])
         tickets = list(tickets)

--- a/ncats_webd/blueprints/metrics/FYcalcs.py
+++ b/ncats_webd/blueprints/metrics/FYcalcs.py
@@ -32,32 +32,32 @@ ALL_STAKEHOLDERS_BY_TYPE = dict()
 def vuln_ticket_counts(FY_START, FY_END, db, severity=0):
     #TODO: Modify print statements to use format() named parameters
     if severity == 0:
-        opened_before_and_still_open = db.TicketDoc.find({'false_positive':False, 'time_opened':{'$lt':FY_START}, 'open':True}).count()
-        opened_before_and_closed_during = db.TicketDoc.find({'false_positive':False, 'time_opened':{'$lt':FY_START}, 'time_closed':{'$gte':FY_START, '$lt':FY_END}}).count()
-        opened_during_and_still_open = db.TicketDoc.find({'false_positive':False, 'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'open':True}).count()
-        opened_during_and_closed_during = db.TicketDoc.find({'false_positive':False, 'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'time_closed':{'$lt':FY_END}}).count()
-        opened_during_and_closed_after = db.TicketDoc.find({'false_positive':False, 'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'time_closed':{'$gte':FY_END}}).count()
-        fp_before = db.TicketDoc.find({'false_positive':True, 'time_opened':{'$lt':FY_START}}).count()
-        fp_during = db.TicketDoc.find({'false_positive':True, 'time_opened':{'$gte':FY_START, '$lt':FY_END}}).count()
-        fp_after = db.TicketDoc.find({'false_positive':True, 'time_opened':{'$gte':FY_END}}).count()
+        opened_before_and_still_open = db.TicketDoc.find({'source': 'nessus', 'false_positive':False, 'time_opened':{'$lt':FY_START}, 'open':True}).count()
+        opened_before_and_closed_during = db.TicketDoc.find({'source': 'nessus', 'false_positive':False, 'time_opened':{'$lt':FY_START}, 'time_closed':{'$gte':FY_START, '$lt':FY_END}}).count()
+        opened_during_and_still_open = db.TicketDoc.find({'source': 'nessus', 'false_positive':False, 'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'open':True}).count()
+        opened_during_and_closed_during = db.TicketDoc.find({'source': 'nessus', 'false_positive':False, 'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'time_closed':{'$lt':FY_END}}).count()
+        opened_during_and_closed_after = db.TicketDoc.find({'source': 'nessus', 'false_positive':False, 'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'time_closed':{'$gte':FY_END}}).count()
+        fp_before = db.TicketDoc.find({'source': 'nessus', 'false_positive':True, 'time_opened':{'$lt':FY_START}}).count()
+        fp_during = db.TicketDoc.find({'source': 'nessus', 'false_positive':True, 'time_opened':{'$gte':FY_START, '$lt':FY_END}}).count()
+        fp_after = db.TicketDoc.find({'source': 'nessus', 'false_positive':True, 'time_opened':{'$gte':FY_END}}).count()
 
-        vulnerable_host_count = len(db.TicketDoc.find({'$or':[
+        vulnerable_host_count = len(db.TicketDoc.find({'source': 'nessus', '$or':[
             {'time_opened':{'$lt':FY_START}, 'open':True},
             {'time_opened':{'$lt':FY_START}, 'time_closed':{'$gte':FY_START, '$lt':FY_END}},
             {'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'open':True},
             {'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'time_closed':{'$lt':FY_END}},
             {'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'time_closed':{'$gte':FY_END}}]}).distinct('ip_int'))
     else:
-        opened_before_and_still_open = db.TicketDoc.find({'false_positive':False, 'time_opened':{'$lt':FY_START}, 'open':True, 'details.severity':severity}).count()
-        opened_before_and_closed_during = db.TicketDoc.find({'false_positive':False, 'time_opened':{'$lt':FY_START}, 'time_closed':{'$gte':FY_START, '$lt':FY_END}, 'details.severity':severity}).count()
-        opened_during_and_still_open = db.TicketDoc.find({'false_positive':False, 'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'open':True, 'details.severity':severity}).count()
-        opened_during_and_closed_during = db.TicketDoc.find({'false_positive':False, 'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'time_closed':{'$lt':FY_END}, 'details.severity':severity}).count()
-        opened_during_and_closed_after = db.TicketDoc.find({'false_positive':False, 'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'time_closed':{'$gte':FY_END}, 'details.severity':severity}).count()
-        fp_before = db.TicketDoc.find({'false_positive':True, 'time_opened':{'$lt':FY_START}, 'details.severity':severity}).count()
-        fp_during = db.TicketDoc.find({'false_positive':True, 'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'details.severity':severity}).count()
-        fp_after = db.TicketDoc.find({'false_positive':True, 'time_opened':{'$gte':FY_END}, 'details.severity':severity}).count()
+        opened_before_and_still_open = db.TicketDoc.find({'source': 'nessus', 'false_positive':False, 'time_opened':{'$lt':FY_START}, 'open':True, 'details.severity':severity}).count()
+        opened_before_and_closed_during = db.TicketDoc.find({'source': 'nessus', 'false_positive':False, 'time_opened':{'$lt':FY_START}, 'time_closed':{'$gte':FY_START, '$lt':FY_END}, 'details.severity':severity}).count()
+        opened_during_and_still_open = db.TicketDoc.find({'source': 'nessus', 'false_positive':False, 'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'open':True, 'details.severity':severity}).count()
+        opened_during_and_closed_during = db.TicketDoc.find({'source': 'nessus', 'false_positive':False, 'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'time_closed':{'$lt':FY_END}, 'details.severity':severity}).count()
+        opened_during_and_closed_after = db.TicketDoc.find({'source': 'nessus', 'false_positive':False, 'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'time_closed':{'$gte':FY_END}, 'details.severity':severity}).count()
+        fp_before = db.TicketDoc.find({'source': 'nessus', 'false_positive':True, 'time_opened':{'$lt':FY_START}, 'details.severity':severity}).count()
+        fp_during = db.TicketDoc.find({'source': 'nessus', 'false_positive':True, 'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'details.severity':severity}).count()
+        fp_after = db.TicketDoc.find({'source': 'nessus', 'false_positive':True, 'time_opened':{'$gte':FY_END}, 'details.severity':severity}).count()
 
-        vulnerable_host_count = len(db.TicketDoc.find({'$or':[
+        vulnerable_host_count = len(db.TicketDoc.find({'source': 'nessus', '$or':[
             {'time_opened':{'$lt':FY_START}, 'open':True, 'details.severity':severity},
             {'time_opened':{'$lt':FY_START}, 'time_closed':{'$gte':FY_START, '$lt':FY_END}, 'details.severity':severity},
             {'time_opened':{'$gte':FY_START, '$lt':FY_END}, 'open':True, 'details.severity':severity},
@@ -120,13 +120,13 @@ def top_vulns(FY_START, FY_END, db, severity=0):
 
     if severity == 0:
         pipeline = [
-        {'$match': {'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}}},
+        {'$match': {'source': 'nessus', 'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}}},
         {'$group': {'_id':{'source_id':'$source_id', 'details_name':'$details.name'}, 'count':{'$sum':1}}},
         {'$sort': {'count':-1}}
         ]
     else:
         pipeline = [
-        {'$match': {'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'details.severity':severity}},
+        {'$match': {'source': 'nessus', 'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'details.severity':severity}},
         {'$group': {'_id':{'source_id':'$source_id', 'details_name':'$details.name'}, 'count':{'$sum':1}}},
         {'$sort': {'count':-1}}
         ]
@@ -430,10 +430,10 @@ Notes: None
     # +* This is the count of 'active hosts' (with at least one port open), at the time the report is generated.
     # +---""")
 
-    total_vuln_hosts = db.TicketDoc.find({'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}}).distinct('ip_int')
-    fed_vuln_hosts = db.TicketDoc.find({'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE[AGENCY_TYPE.FEDERAL]} }).distinct('ip_int')
-    sltt_vuln_hosts = db.TicketDoc.find({'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE['SLTT']} }).distinct('ip_int')
-    private_vuln_hosts = db.TicketDoc.find({'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE[AGENCY_TYPE.PRIVATE]} }).distinct('ip_int')
+    total_vuln_hosts = db.TicketDoc.find({'source': 'nessus', 'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}}).distinct('ip_int')
+    fed_vuln_hosts = db.TicketDoc.find({'source': 'nessus', 'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE[AGENCY_TYPE.FEDERAL]} }).distinct('ip_int')
+    sltt_vuln_hosts = db.TicketDoc.find({'source': 'nessus', 'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE['SLTT']} }).distinct('ip_int')
+    private_vuln_hosts = db.TicketDoc.find({'source': 'nessus', 'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE[AGENCY_TYPE.PRIVATE]} }).distinct('ip_int')
 
     if total_vuln_hosts > 0:
         output['fed_vuln_hosts_pct'] = round((float(len(fed_vuln_hosts)) / len(total_vuln_hosts))*100,1)
@@ -560,7 +560,7 @@ def print_avg_cvss_score(FY_START, FY_END, obj):
     print obj['description']
 
 def unique_vulns(FY_START, FY_END, db):
-    pipeline = [ {'$match': {'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END} } },
+    pipeline = [ {'$match': {'source': 'nessus', 'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END} } },
                  {'$group': {'_id': {'source_id':'$source_id', 'severity':'$details.severity'} } },
                  {'$group': {'_id': { },
                             'low':{'$sum':{'$cond':[{'$eq':['$_id.severity',1]}, 1, 0]}},
@@ -571,7 +571,7 @@ def unique_vulns(FY_START, FY_END, db):
                             } }, ]
     overall_uniq_vulns = list(db.TicketDoc.collection.aggregate(pipeline, cursor={}))
 
-    pipeline = [ {'$match': {'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE[AGENCY_TYPE.FEDERAL]} } },
+    pipeline = [ {'$match': {'source': 'nessus', 'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE[AGENCY_TYPE.FEDERAL]} } },
                  {'$group': {'_id': {'source_id':'$source_id', 'severity':'$details.severity'} } },
                  {'$group': {'_id': { },
                             'low':{'$sum':{'$cond':[{'$eq':['$_id.severity',1]}, 1, 0]}},
@@ -582,7 +582,7 @@ def unique_vulns(FY_START, FY_END, db):
                             } }, ]
     fed_uniq_vulns = list(db.TicketDoc.collection.aggregate(pipeline, cursor={}))
 
-    pipeline = [ {'$match': {'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE['SLTT']} } },
+    pipeline = [ {'$match': {'source': 'nessus', 'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE['SLTT']} } },
                  {'$group': {'_id': {'source_id':'$source_id', 'severity':'$details.severity'} } },
                  {'$group': {'_id': { },
                             'low':{'$sum':{'$cond':[{'$eq':['$_id.severity',1]}, 1, 0]}},
@@ -593,7 +593,7 @@ def unique_vulns(FY_START, FY_END, db):
                             } }, ]
     sltt_uniq_vulns = list(db.TicketDoc.collection.aggregate(pipeline, cursor={}))
 
-    pipeline = [ {'$match': {'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE[AGENCY_TYPE.PRIVATE]} } },
+    pipeline = [ {'$match': {'source': 'nessus', 'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE[AGENCY_TYPE.PRIVATE]} } },
                  {'$group': {'_id': {'source_id':'$source_id', 'severity':'$details.severity'} } },
                  {'$group': {'_id': { },
                             'low':{'$sum':{'$cond':[{'$eq':['$_id.severity',1]}, 1, 0]}},
@@ -605,7 +605,7 @@ def unique_vulns(FY_START, FY_END, db):
     private_uniq_vulns = list(db.TicketDoc.collection.aggregate(pipeline, cursor={}))
 
     '''
-    pipeline = [ {'$match': {'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$nin': FEDERAL+SLTT+PRIVATE} } },
+    pipeline = [ {'$match': {'source': 'nessus', 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$nin': FEDERAL+SLTT+PRIVATE} } },
                  {'$group': {'_id': {'source_id':'$source_id', 'severity':'$details.severity'} } },
                  {'$group': {'_id': { },
                             'low':{'$sum':{'$cond':[{'$eq':['$_id.severity',1]}, 1, 0]}},
@@ -796,7 +796,7 @@ def print_unique_vulns(FY_START, FY_END, obj):
     print obj['description']
 
 def new_vuln_detections(FY_START, FY_END, db):
-    pipeline = [ {'$match': {'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END} } },
+    pipeline = [ {'$match': {'source': 'nessus', 'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END} } },
                  {'$group': {'_id': { },
                              'low':{'$sum':{'$cond':[{'$eq':['$details.severity',1]}, 1, 0]}},
                              'medium':{'$sum':{'$cond':[{'$eq':['$details.severity',2]}, 1, 0]}},
@@ -806,7 +806,7 @@ def new_vuln_detections(FY_START, FY_END, db):
                              } }, ]
     overall_vulns = list(db.TicketDoc.collection.aggregate(pipeline, cursor={}))
 
-    pipeline = [ {'$match': {'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE[AGENCY_TYPE.FEDERAL]} } },
+    pipeline = [ {'$match': {'source': 'nessus', 'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE[AGENCY_TYPE.FEDERAL]} } },
                  {'$group': {'_id': { },
                              'low':{'$sum':{'$cond':[{'$eq':['$details.severity',1]}, 1, 0]}},
                              'medium':{'$sum':{'$cond':[{'$eq':['$details.severity',2]}, 1, 0]}},
@@ -816,7 +816,7 @@ def new_vuln_detections(FY_START, FY_END, db):
                              } }, ]
     fed_vulns = list(db.TicketDoc.collection.aggregate(pipeline, cursor={}))
 
-    pipeline = [ {'$match': {'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE['SLTT']} } },
+    pipeline = [ {'$match': {'source': 'nessus', 'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE['SLTT']} } },
                  {'$group': {'_id': { },
                              'low':{'$sum':{'$cond':[{'$eq':['$details.severity',1]}, 1, 0]}},
                              'medium':{'$sum':{'$cond':[{'$eq':['$details.severity',2]}, 1, 0]}},
@@ -826,7 +826,7 @@ def new_vuln_detections(FY_START, FY_END, db):
                              } }, ]
     sltt_vulns = list(db.TicketDoc.collection.aggregate(pipeline, cursor={}))
 
-    pipeline = [ {'$match': {'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE[AGENCY_TYPE.PRIVATE]} } },
+    pipeline = [ {'$match': {'source': 'nessus', 'false_positive':False, 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$in': ALL_ORGS_BY_TYPE[AGENCY_TYPE.PRIVATE]} } },
                  {'$group': {'_id': { },
                              'low':{'$sum':{'$cond':[{'$eq':['$details.severity',1]}, 1, 0]}},
                              'medium':{'$sum':{'$cond':[{'$eq':['$details.severity',2]}, 1, 0]}},
@@ -837,7 +837,7 @@ def new_vuln_detections(FY_START, FY_END, db):
     private_vulns = list(db.TicketDoc.collection.aggregate(pipeline, cursor={}))
 
     '''
-    pipeline = [ {'$match': {'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$nin': FEDERAL+SLTT+PRIVATE} } },
+    pipeline = [ {'$match': {'source': 'nessus', 'time_opened': {'$gte':FY_START, '$lt':FY_END}, 'owner': {'$nin': FEDERAL+SLTT+PRIVATE} } },
                  {'$group': {'_id': { },
                              'low':{'$sum':{'$cond':[{'$eq':['$details.severity',1]}, 1, 0]}},
                              'medium':{'$sum':{'$cond':[{'$eq':['$details.severity',2]}, 1, 0]}},

--- a/ncats_webd/blueprints/metrics/congressional_metrics.py
+++ b/ncats_webd/blueprints/metrics/congressional_metrics.py
@@ -29,7 +29,7 @@ from pandas import DataFrame, isnull
 
 def tickets_opened_count_pl(org_list, start_date, end_date):
     return [
-           {'$match': {'false_positive':False, 'owner':{'$in':org_list},
+           {'$match': {'source': 'nessus', 'false_positive':False, 'owner':{'$in':org_list},
                        'time_opened':{'$gte':start_date, '$lt':end_date}}
                       },
            {'$group': {'_id': {},
@@ -44,7 +44,7 @@ def tickets_opened_count_pl(org_list, start_date, end_date):
 
 # def open_ticket_count_pl(org_list, start_date, end_date):
 #     return [
-#            {'$match': {'open':True, 'false_positive':False, 'owner':{'$in':org_list},
+#            {'$match': {'open':True, 'source': 'nessus', 'false_positive':False, 'owner':{'$in':org_list},
 #                        'time_opened':{'$gte':start_date, '$lt':end_date}}
 #                       },
 #            {'$group': {'_id': {},
@@ -59,7 +59,7 @@ def tickets_opened_count_pl(org_list, start_date, end_date):
 
 def closed_ticket_count_pl(org_list, start_date, end_date):
     return [
-           {'$match': {'open':False, 'false_positive':False, 'owner':{'$in':org_list},
+           {'$match': {'open':False, 'source': 'nessus','false_positive':False, 'owner':{'$in':org_list},
                        'time_closed':{'$gte':start_date, '$lt':end_date}}
                       },
            {'$group': {'_id': {},
@@ -74,9 +74,9 @@ def closed_ticket_count_pl(org_list, start_date, end_date):
 
 def opened_in_date_range_open_ticket_age_pl(org_list, start_date, end_date):
     return [
-           {'$match': {'$or': [{'open':True, 'false_positive':False, 'owner':{'$in':org_list},
+           {'$match': {'$or': [{'open':True, 'source': 'nessus', 'false_positive':False, 'owner':{'$in':org_list},
                                 'time_opened':{'$gte':start_date, '$lt':end_date}},
-                               {'open':False, 'false_positive':False, 'owner':{'$in':org_list},
+                               {'open':False, 'source': 'nessus', 'false_positive':False, 'owner':{'$in':org_list},
                                 'time_opened':{'$gte':start_date, '$lt':end_date}, 'time_closed':{'$gte':end_date}}]}
                         },
            {'$project': {'severity':'$details.severity',
@@ -86,7 +86,7 @@ def opened_in_date_range_open_ticket_age_pl(org_list, start_date, end_date):
 
 def closed_in_date_range_closed_ticket_age_pl(org_list, start_date, end_date):
     return [
-           {'$match': {'open':False, 'false_positive':False, 'owner':{'$in':org_list},
+           {'$match': {'open':False, 'source': 'nessus', 'false_positive':False, 'owner':{'$in':org_list},
                        'time_closed':{'$gte':start_date, '$lt':end_date}},
                         },
            {'$project': {'severity':'$details.severity',
@@ -96,7 +96,7 @@ def closed_in_date_range_closed_ticket_age_pl(org_list, start_date, end_date):
 
 # def opened_in_date_range_closed_ticket_age_pl(org_list, start_date, end_date):
 #     return [
-#            {'$match': {'open':False, 'false_positive':False, 'owner':{'$in':org_list},
+#            {'$match': {'open':False, 'source': 'nessus', 'false_positive':False, 'owner':{'$in':org_list},
 #                        'time_opened':{'$gte':start_date, '$lt':end_date}},
 #                         },
 #            {'$project': {'severity':'$details.severity',

--- a/ncats_webd/blueprints/metrics/ticketReport.py
+++ b/ncats_webd/blueprints/metrics/ticketReport.py
@@ -89,16 +89,16 @@ def ticket_counts_by_fiscal_year(db, current_fy_start):
     while True:
         next_fy_start = current_fy_start + relativedelta(years=1)
         # Tickets opened during the fiscal year
-        tix_opened = db.TicketDoc.find({'time_opened':{'$gte':current_fy_start, '$lt':next_fy_start}, 'false_positive':False}).count()
+        tix_opened = db.TicketDoc.find({'source': 'nessus', 'time_opened':{'$gte':current_fy_start, '$lt':next_fy_start}, 'false_positive':False}).count()
         # Tickets open at any point during the fiscal year
-        open_tix = db.TicketDoc.find({'$or':[ {'$and': [{'time_opened':{'$gte':current_fy_start, '$lt':next_fy_start}}, {'false_positive':False}]},
+        open_tix = db.TicketDoc.find({'source': 'nessus', '$or':[ {'$and': [{'time_opened':{'$gte':current_fy_start, '$lt':next_fy_start}}, {'false_positive':False}]},
                                               {'$and': [{'time_closed':{'$gte':current_fy_start, '$lt':next_fy_start}}, {'false_positive':False}]},
                                               {'$and': [{'time_opened':{'$lt':current_fy_start}}, {'open':True}, {'false_positive':False}]},
                                               {'$and': [{'time_opened':{'$lt':current_fy_start}}, {'open':False},
                                                         {'time_closed':{'$gte':next_fy_start}}, {'false_positive':False}]}
                                             ]}).count()
         # Tickets closed during the fiscal year
-        tix_closed = db.TicketDoc.find({'time_closed':{'$gte':current_fy_start, '$lt':next_fy_start}, 'false_positive':False}).count()
+        tix_closed = db.TicketDoc.find({'source': 'nessus', 'time_closed':{'$gte':current_fy_start, '$lt':next_fy_start}, 'false_positive':False}).count()
 
         if tix_opened > 0:
             current_fiscal_year = str(current_fy_start.year + 1)
@@ -126,59 +126,59 @@ def all_time_opened_and_closed_breakdown(db):
     Total number of TicketDoc closed in CyHy since inception
     - Count of TicketDoc by Critical/High/Med/Low
     (Excluding False Positives)'''
-    all_time_opened_and_closed = {'total_opened_since_inception':"{:,d}".format(db.TicketDoc.find({'false_positive':False}).count())}
-    all_time_opened_and_closed['total_opened_since_inception_critical'] = "{:,d}".format(db.TicketDoc.find({'false_positive':False,'details.severity':4}).count())
-    all_time_opened_and_closed['total_opened_since_inception_high'] = "{:,d}".format(db.TicketDoc.find({'false_positive':False,'details.severity':3}).count())
-    all_time_opened_and_closed['total_opened_since_inception_medium'] = "{:,d}".format(db.TicketDoc.find({'false_positive':False,'details.severity':2}).count())
-    all_time_opened_and_closed['total_opened_since_inception_low'] = "{:,d}".format(db.TicketDoc.find({'false_positive':False,'details.severity':1}).count())
+    all_time_opened_and_closed = {'total_opened_since_inception':"{:,d}".format(db.TicketDoc.find({'source': 'nessus', 'false_positive':False}).count())}
+    all_time_opened_and_closed['total_opened_since_inception_critical'] = "{:,d}".format(db.TicketDoc.find({'source': 'nessus', 'false_positive':False,'details.severity':4}).count())
+    all_time_opened_and_closed['total_opened_since_inception_high'] = "{:,d}".format(db.TicketDoc.find({'source': 'nessus', 'false_positive':False,'details.severity':3}).count())
+    all_time_opened_and_closed['total_opened_since_inception_medium'] = "{:,d}".format(db.TicketDoc.find({'source': 'nessus', 'false_positive':False,'details.severity':2}).count())
+    all_time_opened_and_closed['total_opened_since_inception_low'] = "{:,d}".format(db.TicketDoc.find({'source': 'nessus', 'false_positive':False,'details.severity':1}).count())
 
-    all_time_opened_and_closed['currently_open'] = "{:,d}".format(db.TicketDoc.find({'false_positive':False,'open':True}).count())
-    all_time_opened_and_closed['currently_open_critical'] = "{:,d}".format(db.TicketDoc.find({'false_positive':False,'details.severity':4,'open':True}).count())
-    all_time_opened_and_closed['currently_open_high'] = "{:,d}".format(db.TicketDoc.find({'false_positive':False,'details.severity':3,'open':True}).count())
-    all_time_opened_and_closed['currently_open_medium'] = "{:,d}".format(db.TicketDoc.find({'false_positive':False,'details.severity':2,'open':True}).count())
-    all_time_opened_and_closed['currently_open_low'] = "{:,d}".format(db.TicketDoc.find({'false_positive':False,'details.severity':1,'open':True}).count())
+    all_time_opened_and_closed['currently_open'] = "{:,d}".format(db.TicketDoc.find({'source': 'nessus', 'false_positive':False,'open':True}).count())
+    all_time_opened_and_closed['currently_open_critical'] = "{:,d}".format(db.TicketDoc.find({'source': 'nessus', 'false_positive':False,'details.severity':4,'open':True}).count())
+    all_time_opened_and_closed['currently_open_high'] = "{:,d}".format(db.TicketDoc.find({'source': 'nessus', 'false_positive':False,'details.severity':3,'open':True}).count())
+    all_time_opened_and_closed['currently_open_medium'] = "{:,d}".format(db.TicketDoc.find({'source': 'nessus', 'false_positive':False,'details.severity':2,'open':True}).count())
+    all_time_opened_and_closed['currently_open_low'] = "{:,d}".format(db.TicketDoc.find({'source': 'nessus', 'false_positive':False,'details.severity':1,'open':True}).count())
 
-    all_time_opened_and_closed['total_closed_since_inception'] = "{:,d}".format(db.TicketDoc.find({'false_positive':False,'open':False}).count())
-    all_time_opened_and_closed['total_closed_since_inception_critical'] = "{:,d}".format(db.TicketDoc.find({'false_positive':False,'details.severity':4,'open':False}).count())
-    all_time_opened_and_closed['total_closed_since_inception_high'] = "{:,d}".format(db.TicketDoc.find({'false_positive':False,'details.severity':3,'open':False}).count())
-    all_time_opened_and_closed['total_closed_since_inception_medium'] = "{:,d}".format(db.TicketDoc.find({'false_positive':False,'details.severity':2,'open':False}).count())
-    all_time_opened_and_closed['total_closed_since_inception_low'] = "{:,d}".format(db.TicketDoc.find({'false_positive':False,'details.severity':1,'open':False}).count())
+    all_time_opened_and_closed['total_closed_since_inception'] = "{:,d}".format(db.TicketDoc.find({'source': 'nessus', 'false_positive':False,'open':False}).count())
+    all_time_opened_and_closed['total_closed_since_inception_critical'] = "{:,d}".format(db.TicketDoc.find({'source': 'nessus', 'false_positive':False,'details.severity':4,'open':False}).count())
+    all_time_opened_and_closed['total_closed_since_inception_high'] = "{:,d}".format(db.TicketDoc.find({'source': 'nessus', 'false_positive':False,'details.severity':3,'open':False}).count())
+    all_time_opened_and_closed['total_closed_since_inception_medium'] = "{:,d}".format(db.TicketDoc.find({'source': 'nessus', 'false_positive':False,'details.severity':2,'open':False}).count())
+    all_time_opened_and_closed['total_closed_since_inception_low'] = "{:,d}".format(db.TicketDoc.find({'source': 'nessus', 'false_positive':False,'details.severity':1,'open':False}).count())
 
     return all_time_opened_and_closed
 
 def report(db, orgs, start, end):
     # opened during period
     opened_tix = list()
-    opened_tix.append(db.tickets.find({'time_opened':{'$gte':start, '$lte':end}, 'false_positive': False}).count())
-    opened_tix.append(db.tickets.find({'time_opened':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['FEDERAL']}, 'false_positive': False}).count())
-    opened_tix.append(db.tickets.find({'time_opened':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['SLTT']}, 'false_positive': False}).count())
-    opened_tix.append(db.tickets.find({'time_opened':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['PRIVATE']}, 'false_positive': False}).count())
+    opened_tix.append(db.tickets.find({'source': 'nessus', 'time_opened':{'$gte':start, '$lte':end}, 'false_positive': False}).count())
+    opened_tix.append(db.tickets.find({'source': 'nessus', 'time_opened':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['FEDERAL']}, 'false_positive': False}).count())
+    opened_tix.append(db.tickets.find({'source': 'nessus', 'time_opened':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['SLTT']}, 'false_positive': False}).count())
+    opened_tix.append(db.tickets.find({'source': 'nessus', 'time_opened':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['PRIVATE']}, 'false_positive': False}).count())
     # closed during period
     closed_tix = list()
-    closed_tix.append(db.tickets.find({'time_closed':{'$gte':start, '$lte':end}}).count())
-    closed_tix.append(db.tickets.find({'time_closed':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['FEDERAL']}}).count())
-    closed_tix.append(db.tickets.find({'time_closed':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['SLTT']}}).count())
-    closed_tix.append(db.tickets.find({'time_closed':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['PRIVATE']}}).count())
+    closed_tix.append(db.tickets.find({'source': 'nessus', 'time_closed':{'$gte':start, '$lte':end}}).count())
+    closed_tix.append(db.tickets.find({'source': 'nessus', 'time_closed':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['FEDERAL']}}).count())
+    closed_tix.append(db.tickets.find({'source': 'nessus', 'time_closed':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['SLTT']}}).count())
+    closed_tix.append(db.tickets.find({'source': 'nessus', 'time_closed':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['PRIVATE']}}).count())
     # reports generated during period
     reports = list()
-    reports.append(db.reports.find({'report_types':REPORT_TYPE.CYHY, 'generated_time':{'$gte':start, '$lte':end}}).count())
-    reports.append(db.reports.find({'report_types':REPORT_TYPE.CYHY, 'generated_time':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['FEDERAL']}}).count())
-    reports.append(db.reports.find({'report_types':REPORT_TYPE.CYHY, 'generated_time':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['SLTT']}}).count())
-    reports.append(db.reports.find({'report_types':REPORT_TYPE.CYHY, 'generated_time':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['PRIVATE']}}).count())
+    reports.append(db.reports.find({'source': 'nessus', 'report_types':REPORT_TYPE.CYHY, 'generated_time':{'$gte':start, '$lte':end}}).count())
+    reports.append(db.reports.find({'source': 'nessus', 'report_types':REPORT_TYPE.CYHY, 'generated_time':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['FEDERAL']}}).count())
+    reports.append(db.reports.find({'source': 'nessus', 'report_types':REPORT_TYPE.CYHY, 'generated_time':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['SLTT']}}).count())
+    reports.append(db.reports.find({'source': 'nessus', 'report_types':REPORT_TYPE.CYHY, 'generated_time':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['PRIVATE']}}).count())
     return opened_tix, closed_tix, reports
 
 def total_open(db, orgs):
     open_non_FP_tix = dict()
-    open_non_FP_tix['total'] = '{:,}'.format(db.tickets.find({'open':True, 'false_positive': False}).count())
-    open_non_FP_tix['federal'] = '{:,}'.format(db.tickets.find({'open':True, 'owner': {'$in': orgs['FEDERAL']}, 'false_positive': False}).count())
-    open_non_FP_tix['SLTT'] = '{:,}'.format(db.tickets.find({'open':True, 'owner': {'$in': orgs['SLTT']}, 'false_positive': False}).count())
-    open_non_FP_tix['private'] = '{:,}'.format(db.tickets.find({'open':True, 'owner': {'$in': orgs['PRIVATE']}, 'false_positive': False}).count())
+    open_non_FP_tix['total'] = '{:,}'.format(db.tickets.find({'open':True, 'source': 'nessus', 'false_positive': False}).count())
+    open_non_FP_tix['federal'] = '{:,}'.format(db.tickets.find({'open':True, 'source': 'nessus', 'owner': {'$in': orgs['FEDERAL']}, 'false_positive': False}).count())
+    open_non_FP_tix['SLTT'] = '{:,}'.format(db.tickets.find({'open':True, 'source': 'nessus', 'owner': {'$in': orgs['SLTT']}, 'false_positive': False}).count())
+    open_non_FP_tix['private'] = '{:,}'.format(db.tickets.find({'open':True, 'source': 'nessus', 'owner': {'$in': orgs['PRIVATE']}, 'false_positive': False}).count())
 
     open_FP_tix = dict()
-    open_FP_tix['total'] = '{:,}'.format(db.TicketDoc.find({'open':True, 'false_positive': True}).count())
-    open_FP_tix['federal'] = '{:,}'.format(db.tickets.find({'open':True, 'owner': {'$in': orgs['FEDERAL']}, 'false_positive': True}).count())
-    open_FP_tix['SLTT'] = '{:,}'.format(db.tickets.find({'open':True, 'owner': {'$in': orgs['SLTT']}, 'false_positive': True}).count())
-    open_FP_tix['private'] = '{:,}'.format(db.tickets.find({'open':True, 'owner': {'$in': orgs['PRIVATE']}, 'false_positive': True}).count())
+    open_FP_tix['total'] = '{:,}'.format(db.TicketDoc.find({'open':True, 'source': 'nessus', 'false_positive': True}).count())
+    open_FP_tix['federal'] = '{:,}'.format(db.tickets.find({'open':True, 'source': 'nessus', 'owner': {'$in': orgs['FEDERAL']}, 'false_positive': True}).count())
+    open_FP_tix['SLTT'] = '{:,}'.format(db.tickets.find({'open':True, 'source': 'nessus', 'owner': {'$in': orgs['SLTT']}, 'false_positive': True}).count())
+    open_FP_tix['private'] = '{:,}'.format(db.tickets.find({'open':True, 'source': 'nessus', 'owner': {'$in': orgs['PRIVATE']}, 'false_positive': True}).count())
     return open_non_FP_tix, open_FP_tix
 
 def print_activity(stats, title, start, end):

--- a/ncats_webd/cybex_queries.py
+++ b/ncats_webd/cybex_queries.py
@@ -17,6 +17,7 @@ def get_open_tickets_dataframe(db, ticket_severity):
     fed_executive_owners = db.RequestDoc.get_all_descendants('EXECUTIVE')
     tix = db.TicketDoc.find(
         {
+            'source': 'nessus',
             'details.severity': ticket_severity,
             'false_positive': False,
             'owner': {
@@ -80,6 +81,7 @@ def get_closed_tickets_dataframe(db, ticket_severity):
     fed_executive_owners = db.RequestDoc.get_all_descendants('EXECUTIVE')
     tix = db.TicketDoc.find(
         {
+            'source': 'nessus',
             'time_closed': {
                 '$gte': closed_since_date
             },
@@ -121,6 +123,7 @@ def get_cybex_dataframe(db, start_date, ticket_severity):
     # Calculate Buckets
     tix = db.TicketDoc.find(
         {
+            'source': 'nessus',
             'details.severity': ticket_severity,
             'false_positive': False,
             'owner': {

--- a/ncats_webd/queries.py
+++ b/ncats_webd/queries.py
@@ -6,10 +6,10 @@ class MapQueries:
     @staticmethod
     def get_open_ticket_loc_by_severity(db, severity=None):
         if severity != None:
-            tickets = db.TicketDoc.collection.find({'open':True, 'details.severity':severity, 'loc.0':{'$ne':None}},
+            tickets = db.TicketDoc.collection.find({'open':True, 'source':'nessus', 'details.severity':severity, 'loc.0':{'$ne':None}},
                                                    {'_id':0,'loc':1,'details.severity':1})
         else:
-            tickets = db.TicketDoc.collection.find({'open':True, 'loc.0':{'$ne':None}},{'_id':0,'loc':1,'details.severity':1})
+            tickets = db.TicketDoc.collection.find({'open':True, 'source':'nessus', 'loc.0':{'$ne':None}}, {'_id':0,'loc':1,'details.severity':1})
         return list(tickets)
 
     @staticmethod
@@ -51,7 +51,7 @@ class DashboardQueries:
             else:
                 current_org_list = [org['_id']]
             tix = list(db.tickets.aggregate([
-                {'$match':{'open':True, 'owner':{'$in':current_org_list}, 'false_positive':False}},
+                {'$match':{'open':True, 'source':'nessus', 'owner':{'$in':current_org_list}, 'false_positive':False}},
                 {'$group': {'_id': {},
                             'critical_tix_open':{'$sum':{'$cond':[{'$eq':['$details.severity',4]}, 1, 0]}},
                             'high_tix_open':{'$sum':{'$cond':[{'$eq':['$details.severity',3]}, 1, 0]}}
@@ -81,7 +81,7 @@ class DashboardQueries:
         results['vulnerable_hosts'] = len(db.tickets.find({'open':True, 'false_positive':False}).distinct('ip_int'))
 
         tix = list(db.tickets.aggregate([
-            {'$match':{'open':True, 'false_positive':False}},
+            {'$match':{'open':True, 'source':'nessus', 'false_positive':False}},
             {'$group': {'_id': {},
                  'low_tix_open':{'$sum':{'$cond':[{'$eq':['$details.severity',1]}, 1, 0]}},
                  'medium_tix_open':{'$sum':{'$cond':[{'$eq':['$details.severity',2]}, 1, 0]}},
@@ -169,11 +169,11 @@ class DashboardQueries:
         results['stakeholders'] = len(election_stakeholders)
         results['addresses'] = db.hosts.find({'owner': {'$in': election_orgs}}).count()
         results['hosts'] = db.hosts.find({'state.up': True, 'owner': {'$in': election_orgs}}).count()
-        results['vulnerable_hosts'] = len(db.tickets.find({'open': True, 'owner': {'$in': election_orgs}, 'false_positive': False}).distinct(
+        results['vulnerable_hosts'] = len(db.tickets.find({'open': True, 'source':'nessus', 'owner': {'$in': election_orgs}, 'false_positive': False}).distinct(
             'ip_int'))
 
         tix = list(db.tickets.aggregate([
-            {'$match': {'open': True, 'owner': {'$in': election_orgs}, 'false_positive': False}},
+            {'$match': {'open': True, 'source':'nessus', 'owner': {'$in': election_orgs}, 'false_positive': False}},
             {'$group': {'_id': {},
                         'low_tix_open': {'$sum': {'$cond': [{'$eq': ['$details.severity', 1]}, 1, 0]}},
                         'medium_tix_open': {'$sum': {'$cond': [{'$eq': ['$details.severity', 2]}, 1, 0]}},


### PR DESCRIPTION
In [CYHYDEV-777](https://jira.ncats.cyber.dhs.gov/browse/CYHYDEV-777), we introduced CyHy tickets with a source of `nmap`.  This PR modifies all of our old `ncats-webd` ticket-related queries so that they explicitly specify the ticket source as `nessus`.  Otherwise, the new `nmap` tickets will be pulled in by these queries and we don't want that, since they don't represent true vulnerabilities.