### PR TITLE
Fix incorrect ticketReport.py query that was incorrectly changed recently

### DIFF
--- a/ncats_webd/blueprints/metrics/ticketReport.py
+++ b/ncats_webd/blueprints/metrics/ticketReport.py
@@ -161,10 +161,10 @@ def report(db, orgs, start, end):
     closed_tix.append(db.tickets.find({'source': 'nessus', 'time_closed':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['PRIVATE']}}).count())
     # reports generated during period
     reports = list()
-    reports.append(db.reports.find({'source': 'nessus', 'report_types':REPORT_TYPE.CYHY, 'generated_time':{'$gte':start, '$lte':end}}).count())
-    reports.append(db.reports.find({'source': 'nessus', 'report_types':REPORT_TYPE.CYHY, 'generated_time':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['FEDERAL']}}).count())
-    reports.append(db.reports.find({'source': 'nessus', 'report_types':REPORT_TYPE.CYHY, 'generated_time':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['SLTT']}}).count())
-    reports.append(db.reports.find({'source': 'nessus', 'report_types':REPORT_TYPE.CYHY, 'generated_time':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['PRIVATE']}}).count())
+    reports.append(db.reports.find({'report_types':REPORT_TYPE.CYHY, 'generated_time':{'$gte':start, '$lte':end}}).count())
+    reports.append(db.reports.find({'report_types':REPORT_TYPE.CYHY, 'generated_time':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['FEDERAL']}}).count())
+    reports.append(db.reports.find({'report_types':REPORT_TYPE.CYHY, 'generated_time':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['SLTT']}}).count())
+    reports.append(db.reports.find({'report_types':REPORT_TYPE.CYHY, 'generated_time':{'$gte':start, '$lte':end}, 'owner': {'$in': orgs['PRIVATE']}}).count())
     return opened_tix, closed_tix, reports
 
 def total_open(db, orgs):


### PR DESCRIPTION
The CyHy team ran the web-based "Weekly Tickets" report and noticed that all of the metrics related to "number of reports generated" were zero.

It turns out that I was a bit overzealous in https://github.com/jsf9k/ncats-webd/pull/15 and I accidentally modified some queries that should not have been touched, since they were querying the `reports` collection, not the `tickets` collection.

This PR rectifies my egregious error.   SHAME!  SHAME!  SHAME! 