### PR TITLE
Pin Flask-Caching Package to < 1.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "cyhy-core >= 0.0.2",
         "docopt >= 0.6.2",
         "flask >= 0.10.1",
-        "Flask-Caching >= 1.4.0",
+        "Flask-Caching >= 1.4.0, < 1.8.0",
         "Flask-Cors >= 2.1.0",
         "Flask-SocketIO >= 2.1",
         "Flask-Uploads >= 0.2.0",


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
In [v1.8.0](https://github.com/sh4nks/flask-caching/releases/tag/v1.8.0), the [Flask-Caching](https://github.com/sh4nks/flask-caching) package officially dropped support for Python 2. However, they did not add a `python_requires` argument to `setup()` in `setup.py`. This allows a Python 3 only version to install on a Python 2 system. I have resolved this by adding a pin to keep the version installed under v1.8.0.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
@dav3r noticed that after the redeploy last night that the dashboard was not working. Upon investigation he saw that `ncats-webd` was crashing after starting due to a `SyntaxError`. I investigated the error messages and determined that the [Flask-Caching](https://github.com/sh4nks/flask-caching) package was causing the failure because of Python 3 only code. Upon further research I realized what happened and how to resolve it, so here we are.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I built a new dashboard AMI using this branch and deployed it in the production environment. @dav3r and I confirmed that the dashboard was working as expected after the deploy finished.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
