### PR TITLE
Update Version Pinning for Flask-SocketIO

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "flask >= 0.10.1",
         "Flask-Caching >= 1.4.0, < 1.8.0",
         "Flask-Cors >= 2.1.0",
-        "Flask-SocketIO >= 2.1",
+        "Flask-SocketIO >= 2.1, < 5",
         "Flask-Uploads >= 0.2.0",
         "gevent >= 1.2.0",
         "gevent-websocket >= 0.9.5",


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the version pin for [Flask-SocketIO](https://github.com/miguelgrinberg/Flask-SocketIO). This will close https://github.com/cisagov/ansible-role-cyhy-reports/issues/21.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

@jsf9k Noticed a [build failure in cisagov/ansible-role-cyhy-reports](https://github.com/cisagov/ansible-role-cyhy-reports/runs/1558182243?check_suite_focus=true) and created https://github.com/cisagov/ansible-role-cyhy-reports/issues/21 to track it for resolution. Upon investigating, I saw that `Flask-SocketIO` `v5.0.0` came out two days ago (2020-12-13), and in that release they updated to use [python-socketio](https://github.com/miguelgrinberg/python-socketio) `>=5.0.2`. One of the changes in v5 of `python-socketio` was the addition of a requirement of [bidict](https://github.com/jab/bidict) `>=0.21.0`. However, in v0.19 `bidict` dropped support for Python 2, which this project still uses.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated testing passes per:
https://github.com/cisagov/ansible-role-ncats-webd/runs/1558580167
https://github.com/cisagov/ansible-role-cyhy-reports/runs/1558749557
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
