### PR TITLE
Add allowDiskUse kwarg to a Mongo Aggregate Call

### DIFF
--- a/ncats_webd/blueprints/stakeholders/stakeholders_info.py
+++ b/ncats_webd/blueprints/stakeholders/stakeholders_info.py
@@ -32,7 +32,7 @@ def get_first_snapshot_times(db, owners):
             {'$group': {'_id':'$owner',
                         'first_snapshot_start_time': {'$first':'$start_time'}}},
             {'$sort': {'_id':1}}
-            ], cursor={}))
+            ], allowDiskUse=True, cursor={}))
 
     first_snapshot_time_dict = dict()
     for i in first_snapshot_time_by_owner:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR simply adds the `allowDiskUse=True` kwarg to a use of the `aggregate()` method on the `snapshots` collection.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

This morning (2020-12-22) I was messaged because a user was unable to get information from the dashboard, which is powered by this project. They were encountering an Internal Server Error. Upon investigating in the log, I found that the following exception was occurring:

```console
OperationFailure: Sort exceeded memory limit of 104857600 bytes, but did not
opt in to external sorting.
```

We came to the conclusion that we should be able to set the `allowDiskUse` kwarg to `True` to allow this aggregate to succeed. We made the change and restarted the service, then verified that it allowed the appropriate functionality. 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This change was made in production and we verified functionality.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
