### PR TITLE
Add Package Dependency and Pin to Avoid Version that Breaks on Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "numpy >= 1.7.1",
         "pandas == 0.19.2",
         "python-dateutil >= 2.2",
+        "python-engineio >= 3, < 3.14",
         "schedule >= 0.3.2",
     ],
 )


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a dependency for [python-engineio](https://github.com/miguelgrinberg/python-engineio) with a version pin.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

The `python-engineio` package is a dependency of [python-socketio](https://github.com/miguelgrinberg/python-socketio), which is itself a dependency of [Flask-SocketIO](https://github.com/miguelgrinberg/Flask-SocketIO), and `Flask-SocketIO` is a requirement for this project.

I noticed a problem with the dashboard in my testing environment from the following Python 3 only code:

```python
from json import JSONDecodeError
```

Upon investigation I saw that this was added in `v3.14`. Someone else created an issue (https://github.com/miguelgrinberg/python-engineio/issues/206), and based on the developer's response we should expect no support for Python 2.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I deployed this in my testing environment and verified that the dashboard worked as expected with the correct version of `python-engineio` installed.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
