### PR TITLE
Add _id field to Cyber Exposure CSV output

### DIFF
--- a/ncats_webd/cybex_queries.py
+++ b/ncats_webd/cybex_queries.py
@@ -20,7 +20,7 @@ def get_open_tickets_dataframe(db, ticket_severity):
     fed_executive_owners = db.RequestDoc.get_all_descendants("EXECUTIVE")
 
     TICKET_PROJECTION = {
-        "_id": False,
+        "_id": True,
         "details.cve": True,
         "details.kev": True,
         "details.name": True,
@@ -109,7 +109,7 @@ def get_closed_tickets_dataframe(db, ticket_severity):
     fed_executive_owners = db.RequestDoc.get_all_descendants("EXECUTIVE")
 
     TICKET_PROJECTION = {
-        "_id": False,
+        "_id": True,
         "details.cve": True,
         "details.kev": True,
         "details.name": True,
@@ -245,6 +245,7 @@ def csv_get_open_tickets(db, ticket_severity):
             index=False,
             date_format="%Y-%m-%d %H:%M:%S",
             columns=[
+                "id",
                 "owner",
                 "ip",
                 "port",
@@ -278,6 +279,7 @@ def csv_get_closed_tickets(db, ticket_severity):
             index=False,
             date_format="%Y-%m-%d %H:%M:%S",
             columns=[
+                "id",
                 "owner",
                 "ip",
                 "port",

--- a/ncats_webd/cybex_queries.py
+++ b/ncats_webd/cybex_queries.py
@@ -279,7 +279,7 @@ def csv_get_closed_tickets(db, ticket_severity):
             index=False,
             date_format="%Y-%m-%d %H:%M:%S",
             columns=[
-                "id",
+                "_id",
                 "owner",
                 "ip",
                 "port",

--- a/ncats_webd/cybex_queries.py
+++ b/ncats_webd/cybex_queries.py
@@ -245,7 +245,7 @@ def csv_get_open_tickets(db, ticket_severity):
             index=False,
             date_format="%Y-%m-%d %H:%M:%S",
             columns=[
-                "id",
+                "_id",
                 "owner",
                 "ip",
                 "port",

--- a/ncats_webd/cybex_queries.py
+++ b/ncats_webd/cybex_queries.py
@@ -20,7 +20,7 @@ def get_open_tickets_dataframe(db, ticket_severity):
     fed_executive_owners = db.RequestDoc.get_all_descendants("EXECUTIVE")
 
     TICKET_PROJECTION = {
-        "_id": True,
+        "id": True,
         "details.cve": True,
         "details.kev": True,
         "details.name": True,
@@ -109,7 +109,7 @@ def get_closed_tickets_dataframe(db, ticket_severity):
     fed_executive_owners = db.RequestDoc.get_all_descendants("EXECUTIVE")
 
     TICKET_PROJECTION = {
-        "_id": True,
+        "id": True,
         "details.cve": True,
         "details.kev": True,
         "details.name": True,

--- a/ncats_webd/cybex_queries.py
+++ b/ncats_webd/cybex_queries.py
@@ -20,7 +20,7 @@ def get_open_tickets_dataframe(db, ticket_severity):
     fed_executive_owners = db.RequestDoc.get_all_descendants("EXECUTIVE")
 
     TICKET_PROJECTION = {
-        "id": True,
+        "_id": True,
         "details.cve": True,
         "details.kev": True,
         "details.name": True,
@@ -109,7 +109,7 @@ def get_closed_tickets_dataframe(db, ticket_severity):
     fed_executive_owners = db.RequestDoc.get_all_descendants("EXECUTIVE")
 
     TICKET_PROJECTION = {
-        "id": True,
+        "_id": True,
         "details.cve": True,
         "details.kev": True,
         "details.name": True,


### PR DESCRIPTION
# <!-- Ticket Projection _id values update --> #
## Description ##
This PR adds the "id" associated with the tickets listed in the open/closed urgent ticket csvs that accompany the Cybex Scorecard.

## 💭 Motivation and context ##
There is a need to see unique ticket identifiers on urgent tickets for tracking vulnerabilities open/closed state and when it closed by using the IP address.

Resolves https://github.com/cisagov/cyhy-system/issues/76.

## 🧪 Testing ##

Done by @dav3r:
* I created a script (a simplified version of [`create_snapshots_reports_scorecard.py`](https://github.com/cisagov/cyhy-reports/blob/develop/extras/create_snapshots_reports_scorecard.py) that only included code relevant to generating the Cyber Exposure "urgent" CSVs) in order to test these changes on my local system.
* I then ran that script using read-only Production credentials (to ensure no unintended data modification) with the current Production `ncats-webd` code and verified that two baseline CSVs were created that did not contain the ticket `_id` field.
* Then, I locally checked out and switched to using the [code branch for this PR](https://github.com/cisagov/ncats-webd/tree/cybex-urgent-ticket-ids) and I re-ran the script.
* I can confirm that both of those CSVs correctly included the ticket `_id` field for each row and also that the count of rows in each CSV was unchanged from the baseline. 🎉 

Note from @mcdonnnj:
I have removed the LGTM check requirement from the branch protection for the `develop` branch. LGTM has been shut down and any checks/requirements in other repositories have already been removed.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - eschew scope creep!
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](https://github.com/cisagov/crossfeed/blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).

## ✅ Post-merge checklist ##
 - [x] Someone from @cisagov/team-ois (most likely @dav3r) deploys this change to Production.