### PR TITLE
Update the version pin for the `Flask-Cors` package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "docopt >= 0.6.2",
         "flask >= 0.10.1",
         "Flask-Caching >= 1.4.0, < 1.8.0",
-        "Flask-Cors >= 2.1.0",
+        "Flask-Cors >= 2.1.0, < 4",
         "Flask-SocketIO >= 2.1, < 5",
         "Flask-Uploads >= 0.2.0",
         "gevent >= 1.2.0",

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,10 @@ setup(
         "docopt >= 0.6.2",
         "flask >= 0.10.1",
         "Flask-Caching >= 1.4.0, < 1.8.0",
+        # The Flask-Cors package no longer support Python 2 as of version 4.0.0.
+        # However, the build process for the package is still producing wheels that
+        # are marked for Python 2 support. Please see the following issue for more
+        # information: https://github.com/corydolphin/flask-cors/issues/339
         "Flask-Cors >= 2.1.0, < 4",
         "Flask-SocketIO >= 2.1, < 5",
         "Flask-Uploads >= 0.2.0",


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the version pin for the [Flask-Cors] package to include an upper bound.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The [4.0.0 release] removes support for Python versions < 3.8. However, the build process for releases was not updated and so the wheel released is still marked with Python 2 support (and no `Requires-Python` attribute). As a result the latest version of the package is pulled down,  which is unable to run in a Python 2 environment, and the package is unable to run.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I was able to successfully start this package through its entry point once I installed it with the updated version pin in place. It has been running in our production CyHy environment as normal.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).

[4.0.0 release]: https://github.com/corydolphin/flask-cors/releases/tag/4.0.0
[Flask-Cors]: https://pypi.org/project/Flask-Cors/